### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Feel free to fork them!
 ## Usage
 
     $ cd tmux
-    $ fpm-cook
+    $ fpm-cook package
       [watching the output]
     $ sudo dpkg -i pkg/*.deb
     $ fpm-cook clean


### PR DESCRIPTION
Looks like recent releasees of fpm-cookery need `package` command to be given. I tried building Nginx package and until I passed `package` explicitly, it wasn't compiled.
