### PR TITLE
Use Apache mirror that actually works

### DIFF
--- a/solr/recipe.rb
+++ b/solr/recipe.rb
@@ -8,7 +8,7 @@ class Solr < FPM::Cookery::Recipe
   revision 7
   arch     'all'
   homepage 'http://lucene.apache.org/solr/'
-  source   "http://www.eng.lsu.edu/mirrors/apache/lucene/solr/#{version}/apache-solr-#{version}.tgz"
+  source   "http://www.eu.apache.org/dist//lucene/solr/#{version}/apache-solr-#{version}.tgz"
   md5      '949b145669a6c9517b2fef32b58f679e'
 
   section 'database'


### PR DESCRIPTION
The one Solr recipe was using before now routinely responds with 403. I hope EU mirror is an OK default.
