### PR TITLE
Add haproxy recipe

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,0 +1,86 @@
+#---------------------------------------------------------------------
+# Example configuration for a possible web application.  See the
+# full configuration options online.
+#
+#   http://haproxy.1wt.eu/download/1.5/doc/configuration.txt
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# Global settings
+#---------------------------------------------------------------------
+global
+    # to have these messages end up in /var/log/haproxy.log you will
+    # need to:
+    #
+    # 1) configure syslog to accept network log events.  This is done
+    #    by adding the '-r' option to the SYSLOGD_OPTIONS in
+    #    /etc/sysconfig/syslog
+    #
+    # 2) configure local2 events to go to the /var/log/haproxy.log
+    #   file. A line like the following can be added to
+    #   /etc/sysconfig/syslog
+    #
+    #    local2.*                       /var/log/haproxy.log
+    #
+    log         127.0.0.1 local2
+
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option http-server-close
+    option forwardfor       except 127.0.0.0/8
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000
+
+#---------------------------------------------------------------------
+# main frontend which proxys to the backends
+#---------------------------------------------------------------------
+frontend  main *:5000
+    acl url_static       path_beg       -i /static /images /javascript /stylesheets
+    acl url_static       path_end       -i .jpg .gif .png .css .js
+
+    use_backend static          if url_static
+    default_backend             app
+
+#---------------------------------------------------------------------
+# static backend for serving up images, stylesheets and such
+#---------------------------------------------------------------------
+backend static
+    balance     roundrobin
+    server      static 127.0.0.1:4331 check
+
+#---------------------------------------------------------------------
+# round robin balancing between the various backends
+#---------------------------------------------------------------------
+backend app
+    balance     roundrobin
+    server  app1 127.0.0.1:5001 check
+    server  app2 127.0.0.1:5002 check
+    server  app3 127.0.0.1:5003 check
+    server  app4 127.0.0.1:5004 check
+

--- a/haproxy/haproxy.logrotate
+++ b/haproxy/haproxy.logrotate
@@ -1,0 +1,12 @@
+/var/log/haproxy.log {
+    daily
+    rotate 10
+    missingok
+    notifempty
+    compress
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/haproxy/post-install
+++ b/haproxy/post-install
@@ -1,0 +1,1 @@
+/sbin/chkconfig --add haproxy

--- a/haproxy/post-uninstall
+++ b/haproxy/post-uninstall
@@ -1,0 +1,3 @@
+if [ $1 -ge 1 ]; then
+  /sbin/service haproxy condrestart > /dev/null 2>&1 || :
+fi

--- a/haproxy/pre-install
+++ b/haproxy/pre-install
@@ -1,0 +1,1 @@
+%{_sbindir}/useradd -c "HAProxy User" -s /bin/false -r -d %{_localstatedir}/lib/haproxy haproxy 2>/dev/null || :

--- a/haproxy/pre-uninstall
+++ b/haproxy/pre-uninstall
@@ -1,0 +1,4 @@
+if [ $1 = 0 ]; then
+  /sbin/service haproxy stop >/dev/null 2>&1
+  /sbin/chkconfig --del haproxy 
+fi

--- a/haproxy/recipe.rb
+++ b/haproxy/recipe.rb
@@ -1,0 +1,60 @@
+require 'fpm/package/python'
+
+class Haproxy < FPM::Cookery::Recipe
+  homepage 'http://haproxy.1wt.eu/'
+  source 'http://haproxy.1wt.eu/download/1.5/src/devel/haproxy-1.5-dev17.tar.gz'
+  md5 'b8deab9989e6b9925410b0bc44dd4353'
+
+  name 'haproxy'
+  version '1.5.dev17'
+  revision '1'
+
+  description 'The Reliable, High Performance TCP/HTTP Load Balancer'
+
+  depends 'openssl', 'pcre', 'zlib'
+  build_depends 'openssl-devel', 'pcre-devel', 'zlib-devel'
+
+  config_files '/etc/haproxy/haproxy.cfg'
+
+  pre_install 'pre-install'
+  post_install 'post-install'
+  pre_uninstall 'pre-uninstall'
+  post_uninstall 'post-uninstall'
+
+  # WARNING: This blindly assumes a new kernel and building on the target box.
+  def build
+    make 'TARGET' => 'linux2628', 'CPU' => 'native', 'USE_PCRE' => '1', 'USE_OPENSSL' => '1', 'USE_ZLIB' => '1'
+
+    # halog
+    make '-C', 'contrib/halog'
+  end
+
+  def install
+    with_trueprefix do
+      make :install, 'DESTDIR' => destdir, 'PREFIX' => prefix, 'DOCDIR' => haproxy_doc
+    end
+
+    etc('haproxy').install workdir('haproxy.cfg')
+
+    etc('logrotate.d').install(workdir('haproxy.logrotate'), 'haproxy')
+
+    etc('rc.d/init.d').install('examples/haproxy.init', 'haproxy')
+    chmod 0755, etc('rc.d/init.d/haproxy')
+
+    #GZip man page
+    safesystem '/bin/gzip', man1('haproxy.1')
+
+    haproxy_doc.install Dir['doc/*']
+
+    share('haproxy').install Dir['examples/errorfiles/*']
+
+    var('lib/haproxy').mkpath
+
+    # halog
+    bin.install 'contrib/halog/halog'
+  end
+
+  def haproxy_doc(path = nil)
+    doc("haproxy-#{version}")
+  end
+end


### PR DESCRIPTION
This installs 1.5-dev17.

One strange note: I seem to need a `require 'fpm/package/python'` at the top of the haproxy recipe to get it to run.  Without that I get an uninitialized constant FPM::Package::Python when I try to run fpm-cook.
