### PR TITLE
Make ruby search for correct gzip path

### DIFF
--- a/haproxy/recipe.rb
+++ b/haproxy/recipe.rb
@@ -42,7 +42,8 @@ class Haproxy < FPM::Cookery::Recipe
     chmod 0755, etc('rc.d/init.d/haproxy')
 
     #GZip man page
-    safesystem '/bin/gzip', man1('haproxy.1')
+    gzip_path = find_executable 'gzip'
+    safesystem gzip_path, man1('haproxy.1')
 
     haproxy_doc.install Dir['doc/*']
 

--- a/nginx/recipe.rb
+++ b/nginx/recipe.rb
@@ -62,7 +62,8 @@ class Nginx < FPM::Cookery::Recipe
 
     # man page
     man8.install Dir['objs/nginx.8']
-    system 'gzip', man8/'nginx.8'
+    gzip_path = find_executable 'gzip'
+    safesystem gzip_path, man8/'nginx.8'
 
     # support dirs
     %w( run lock log/nginx lib/nginx ).map do |dir|

--- a/offlineimap/recipe.rb
+++ b/offlineimap/recipe.rb
@@ -18,7 +18,8 @@ class OfflineIMAP < FPM::Cookery::Recipe
 
     make
     safesystem 'make -C docs man'
-    safesystem 'gzip offlineimap.1'
+    gzip_path = find_executable 'gzip'
+    safesystem gzip_path, 'offlineimap.1'
   end
 
   def install

--- a/openresty/recipe.rb
+++ b/openresty/recipe.rb
@@ -88,7 +88,10 @@ class Openresty < FPM::Cookery::Recipe
 
     # man page
     man8.install Dir['objs/nginx.8']
-    system 'gzip', man8/'nginx.8'
+
+    # gzip man page
+    gzip_path = find_executable 'gzip'
+    safesystem gzip_path, 'man8/nginx.8'
 
     # support dirs
     %w( run lock log/nginx lib/nginx ).map do |dir|


### PR DESCRIPTION
Was having issues running recipes on machines that had gzip under a different path (OSX for example has it at `/usr/bin/gzip`